### PR TITLE
passing the browser option to --open in webpack commnand

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "flow-coverage": "flow-coverage-report --threshold 92 -i 'src/**/*.js' -i 'src/**/*.jsx' --collectCoverageFrom=!src/styled/**.* -t html -t json -t text",
     "lint": "eslint --ext .js --ext .jsx src test scripts",
     "start": "./scripts/start",
-    "start:client-dev": "webpack serve --mode development --open --hot",
+    "start:client-dev": "webpack serve --mode development --open 'google-chrome' --hot",
     "server:start": "node ./server/server.js",
     "server:watch": "babel src --ignore src/client --watch --out-dir dist --copy-files --source-maps inline",
     "test": "./scripts/test --env.NODE_ENV=test",


### PR DESCRIPTION
The --open option in webpack command expects name of the browser in which the application needs to be opened. The application compiles fine on mac, however on ubuntu it fails. It is taking --hot the next param as the program and fails with following  error 
`events.js:174
      throw er; // Unhandled 'error' event
      ^

Error: spawn --hot ENOENT
    at Process.ChildProcess._handle.onexit (internal/child_process.js:240:19)
    at onErrorNT (internal/child_process.js:415:16)
    at process._tickCallback (internal/process/next_tick.js:63:19)
Emitted 'error' event at:
    at Process.ChildProcess._handle.onexit (internal/child_process.js:246:12)
    at onErrorNT (internal/child_process.js:415:16)
    at process._tickCallback (internal/process/next_tick.js:63:19)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
`
There are two ways to fix this, one is to remove the --open option or to pass a browsers as the value.